### PR TITLE
Fix code sample typo in libtool/plugins

### DIFF
--- a/chapters/libtool/plugins.xmli
+++ b/chapters/libtool/plugins.xmli
@@ -107,7 +107,7 @@
 	<programlisting><![CDATA[
 # automake needed when not using sub-configured libltdl
 # subdir-objects only needed when using non-recursive inline build
-AM_INIT_AUTOMAKE([subdir-objects]
+AM_INIT_AUTOMAKE([subdir-objects])
 
 # the inline build *requires* the configure header, although the name
 # is not really important


### PR DESCRIPTION
Missing parenthesis.
