### PR TITLE
Mention calling m4_include before AC_INIT

### DIFF
--- a/chapters/autoconf/macros/external.xmli
+++ b/chapters/autoconf/macros/external.xmli
@@ -106,6 +106,12 @@ AUTOTOOLS_MYTHBUSTER
         <function>#include</function> directive of the C programming language, and simply copies
         over the content of the file.
       </para>
+
+      <para>
+        To not include comments starting with <literal>#</literal> in the generated
+        <filename>configure</filename> script call the <function>m4_include</function> before the
+        <function>AC_INIT</function>.
+      </para>
     </example>
 
     <para>


### PR DESCRIPTION
If m4_include is called before the AC_INIT the generated configure script doesn't include # comments from the included files.