### PR TITLE
automake: use POSIX make syntax

### DIFF
--- a/chapters/automake/nonrecursive.xmli
+++ b/chapters/automake/nonrecursive.xmli
@@ -224,7 +224,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = pkgconfig/foo.pc pkgconfig/foo-bar.pc
 
 %-bar.pc: %.pc
-        $(LN_S) $^ $@
+        $(LN_S) $< $@
 ]]></programlisting>
 
     <para>
@@ -235,9 +235,8 @@ pkgconfig_DATA = pkgconfig/foo.pc pkgconfig/foo-bar.pc
     </para>
 
     <para>
-      To avoid this kind of problem, you can make use of
-      <application>GNU make</application> extended functions in the
-      rules, to transform the path from full-relative form to base
+      To avoid this kind of problem, you can make use of the alternative
+      forms to transform the path from full-relative form to base
       form (without the path). For instance the fragment above should
       be replaced by the following:
     </para>
@@ -247,7 +246,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = pkgconfig/foo.pc pkgconfig/foo-bar.pc
 
 %-bar.pc: %.pc
-        $(LN_S) $(notdir $^) $@
+        $(LN_S) $(<F) $@
 ]]></programlisting>
   </section>
 </section>

--- a/chapters/automake/silent.xmli
+++ b/chapters/automake/silent.xmli
@@ -220,7 +220,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
 
       <programlisting><![CDATA[
 %-bar.pc: %.pc
-        $(AM_V_GEN)$(LN_S) $(notdir $^) $@
+        $(AM_V_GEN)$(LN_S) $(<F) $@
 ]]></programlisting>
     </example>
   </section>


### PR DESCRIPTION
POSIX provides a shorthand for notdir-like functionality. Use that instead of recommending GNU Make specific syntax.

https://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html
> Each of the internal macros has an alternative form. When an uppercase
> 'D' or 'F' is appended to any of the macros, the meaning shall be changed
> to the directory part for 'D' and filename part for 'F'.